### PR TITLE
add hostUrl and hAppUrl as optionals to makeWebClient

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export interface MakeWebClientOptionals {
   hostUrl?: string,
+  hAppUrl?: string,
   dnaHash?: string,
   preCall?: PreCallFunction,
   postCall?: PostCallFunction,


### PR DESCRIPTION
Add hostUrl and hAppUrl as optionals to makeWebClient. Allows for different granularity in specifying how the host will be found for testing