### PR TITLE
quick fix -removed second reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "files": [
     "lib"
   ],
-  "author": " ",
+  "author": "",
   "license": "GPL-3",
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
  * - Setting up a websocket connection to the interceptor to sign commits on request
  * - Wrapping and unwrapping calls to and from the interceptor such that they look like regular holochain calls
  *
- * Using this library to make a Holochain web UI Holo compatible is very easy provide you are already using hc-web-client
+ * Using this library to make a Holochain web UI Holo compatible is very easy provided you are already using hc-web-client
  * to connect to holochain. In this case an app can be converted by adding the following lines to a page load function
  * ```javascript
  * let holochainclient = require('@holochain/hc-web-client') // this should already be part of your web UI
@@ -148,7 +148,6 @@ const hClient = (function () {
       hostUrl = optionals.hostUrl
     }
 
-    let _happId: string
     if (optionals.happId && optionals.happId !== undefined) {
       _happId = optionals.happId
     } else {


### PR DESCRIPTION
 let _happId:string was created a second time within makeWebClient. This was an oversight and creates a reference error. _happId should remain a global var in this file.